### PR TITLE
Compatibility with other Primary Key name

### DIFF
--- a/lib/populator/factory.rb
+++ b/lib/populator/factory.rb
@@ -73,7 +73,7 @@ module Populator
     end
     
     def last_id_in_database
-      @last_id_in_database ||= @model_class.connection.select_value("SELECT id FROM #{@model_class.quoted_table_name} ORDER BY id DESC", "#{@model_class.name} Last ID").to_i
+      @last_id_in_database ||= @model_class.connection.select_value("SELECT #{@model_class.primary_key} FROM #{@model_class.quoted_table_name} ORDER BY #{@model_class.primary_key} DESC", "#{@model_class.name} Last ID").to_i
     end
     
     def columns_sql


### PR DESCRIPTION
Hello,

I use your (great) gem in a project, but I encountered an issue.
The primary keys of my database aren't name 'id', so it raises an error in the method 'last_id_in_database' of the file 'factory.rb'.
I just hack a little bit of code to make it works with the 'primary_key' attribute of ActiveRecord::Base.
Now it's fine, so if it can help...

p.s. : it's the first time I make a pull request, I don't know if it's what we usually expect in a description. Forgive me :)
