### PR TITLE
Pass iterator to populate block to reduce duplicates

### DIFF
--- a/lib/populator/factory.rb
+++ b/lib/populator/factory.rb
@@ -48,9 +48,10 @@ module Populator
     # :per_query limit option is reached.
     def build_records(amount, per_query, &block)
       amount.times do
-        record = Record.new(@model_class, last_id_in_database + @records.size + 1)
+        index = last_id_in_database + @records.size + 1
+        record = Record.new(@model_class, index)
         @records << record
-        block.call(record) if block
+        block.call(record, index) if block
         save_records if @records.size >= per_query
       end
     end

--- a/spec/populator/factory_spec.rb
+++ b/spec/populator/factory_spec.rb
@@ -43,6 +43,18 @@ describe Populator::Factory do
       @factory.populate(5, :per_query => 2)
       $queries_executed.grep(/^insert/i).should have(3).records
     end
+
+    it 'should pass index to populator block to help eliminate duplicates' do
+      Product.delete_all
+      indexes = []
+      num_to_populate = 5
+      @factory.populate(num_to_populate) do |product, index|
+        product.name = "unique name #{index}"
+      end
+      product_names = Product.all.map(&:name)
+      expected_product_names = (1..num_to_populate).to_a.map { |index| "unique name #{index}" }
+      product_names.should == expected_product_names
+    end
   end
 
   it "should only use two queries when nesting factories (one for each class)" do


### PR DESCRIPTION
I've used Populator on a project where a string field had to be unique. Using Populator.words(3) can still produce duplicates. How about passing an index to the populate block a la Sham?

``` ruby
Product.populate(5) do |product, index|
  product.name = "unique name #{index}"
end
```

The pull request was tested with SQLite3.
