### PR TITLE
Minor tweak to last-ID lookup

### DIFF
--- a/lib/populator/factory.rb
+++ b/lib/populator/factory.rb
@@ -74,7 +74,7 @@ module Populator
     end
 
     def last_id_in_database
-      @last_id_in_database ||= @model_class.connection.select_value("SELECT #{@model_class.primary_key} FROM #{@model_class.quoted_table_name} ORDER BY #{@model_class.primary_key} DESC", "#{@model_class.name} Last ID").to_i
+      @last_id_in_database ||= @model_class.connection.select_value("SELECT MAX(#{@model_class.primary_key}) FROM #{@model_class.quoted_table_name}", "#{@model_class.name} Last ID").to_i
     end
 
     def columns_sql


### PR DESCRIPTION
Hi Ryan,

While studying performance of a task that generates a ton of dummy models for load testing, I noticed a lot of "SELECT id FROM `table_name` ORDER BY id DESC" calls, and traced them to Populator looking for the last ID for a model. Since all you want is one integer, it doesn't make sense for the database to pass _all_ the rows' IDs back to ActiveRecord when it's just going to pluck out one value :-).

I initially just added "... LIMIT 1", but thought "SELECT MAX(id) FROM `table_name`" was more semantically correct, so that's what the patch does. I'm no SQL standards expert, but I checked that MAX(x) works on string columns too, in both MySQL and SQLite. Sorry for no test for this - didn't seem like stubbing select_value to check the string literal was useful, and couldn't think of another meaningful thing to test...

(I've learned a ton from your videos, and great tools like Populator - thanks!)
...Bryan Stearns
