### PR TITLE
Change 'sanitize' to 'connection.quote'

### DIFF
--- a/lib/populator/factory.rb
+++ b/lib/populator/factory.rb
@@ -83,7 +83,7 @@ module Populator
 
     def rows_sql_arr
       @records.map do |record|
-        quoted_attributes = record.attribute_values.map { |v| @model_class.sanitize(v) }
+        quoted_attributes = record.attribute_values.map { |v| @model_class.connection.quote(v) }
         "(#{quoted_attributes.join(', ')})"
       end
     end


### PR DESCRIPTION
`sanitize` no longer supported (apparently was never supposed to be supported) in Rails 5.1: https://github.com/rails/rails/issues/28947